### PR TITLE
Docker recipes and elasticsearch.yml

### DIFF
--- a/nesta/production/README-elasticsearch.rst
+++ b/nesta/production/README-elasticsearch.rst
@@ -40,8 +40,18 @@ python 3.6
 
 Docker
 ------
-- max file descriptors
-- docker-compose
+the :code:`docker-compose.yml` needs to include ulimits settings::
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+          soft: 65536
+          hard: 65536
+
+Recipes for http or https clusters can be found in: :code:`nesta/production/scripts/elasticsearch`
+
+There is also an EC2 AMI for a http node stored in the London region: :code:`elasticsearch node London vX`
 
 Reindexing data from a remote cluster
 -------------------------------------

--- a/nesta/production/scripts/elasticsearch/ec2-http/Dockerfile
+++ b/nesta/production/scripts/elasticsearch/ec2-http/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+
+RUN bin/elasticsearch-plugin install discovery-ec2 --batch
+RUN bin/elasticsearch-plugin install repository-s3 --batch
+
+ADD ./elasticsearch.yml config/elasticsearch.yml

--- a/nesta/production/scripts/elasticsearch/ec2-http/docker-compose.yml
+++ b/nesta/production/scripts/elasticsearch/ec2-http/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+services:
+  elasticsearch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: elasticsearch-node
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - 9200:9200
+      - 9300:9300
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+          soft: 65536
+          hard: 65536
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+
+volumes:
+  esdata1:
+    driver: local

--- a/nesta/production/scripts/elasticsearch/ec2-http/elasticsearch.yml
+++ b/nesta/production/scripts/elasticsearch/ec2-http/elasticsearch.yml
@@ -1,0 +1,16 @@
+cluster.name: ec2-elastic-cluster
+
+network.host: 0.0.0.0
+network.publish_host: _ec2:privateIpv4_
+
+# Discovery
+discovery.zen.minimum_master_nodes: 2
+discovery.zen.hosts_provider: ec2
+# Use this AWS instance tag to discover potential server peers.
+# Create a tag with key=role and value=elastic-cluster-member
+discovery.ec2.tag.role: elastic-cluster-member
+discovery.ec2.endpoint: ec2.eu-west-2.amazonaws.com
+
+# CORS
+http.cors.enabled: true
+#http.cors.allow-methods: GET

--- a/nesta/production/scripts/elasticsearch/ec2-https/Dockerfile
+++ b/nesta/production/scripts/elasticsearch/ec2-https/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+
+RUN bin/elasticsearch-plugin install discovery-ec2 --batch
+RUN bin/elasticsearch-plugin install repository-s3 --batch
+
+RUN mkdir config/certs
+ADD ./elasticsearch.yml config/elasticsearch.yml
+ADD ./elastic-certificates.p12 config/certs/elastic-certificates.p12
+
+USER root
+RUN chown elasticsearch:elasticsearch config/certs/elastic-certificates.p12
+USER elasticsearch

--- a/nesta/production/scripts/elasticsearch/ec2-https/docker-compose.yml
+++ b/nesta/production/scripts/elasticsearch/ec2-https/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+services:
+  elasticsearch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: elasticsearch-node
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - 9200:9200
+      - 9300:9300
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+          soft: 65536
+          hard: 65536
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+
+volumes:
+  esdata1:
+    driver: local

--- a/nesta/production/scripts/elasticsearch/ec2-https/elasticsearch.yml
+++ b/nesta/production/scripts/elasticsearch/ec2-https/elasticsearch.yml
@@ -1,0 +1,29 @@
+cluster.name: ec2-elastic-cluster
+
+network.host: 0.0.0.0
+network.publish_host: _ec2:privateIpv4_
+
+# Discovery
+discovery.zen.minimum_master_nodes: 2
+discovery.zen.hosts_provider: ec2
+# Use this AWS instance tag to discover potential server peers.
+# Create a tag with key=role and value=elastic-cluster-member
+discovery.ec2.tag.role: elastic-cluster-test
+discovery.ec2.endpoint: ec2.eu-west-2.amazonaws.com
+
+# CORS
+http.cors.enabled: true
+http.cors.allow-methods: GET
+
+# Encryption
+# certificates need to be generated, as per the elastisearch documentation
+xpack.security.enabled: true
+xpack.security.transport.ssl.enabled: true
+xpack.security.transport.ssl.verification_mode: certificate
+xpack.security.transport.ssl.keystore.path: certs/elastic-certificates.p12
+xpack.security.transport.ssl.truststore.path: certs/elastic-certificates.p12
+# Client comms
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.keystore.path: certs/elastic-certificates.p12
+xpack.security.http.ssl.truststore.path: certs/elastic-certificates.p12
+xpack.security.http.ssl.client_authentication: optional


### PR DESCRIPTION
These are files for either a **http** or a **https** cluster. (the latter requires certificates to be set up)

Docs are also updated to reflect the above.