### PR TITLE
Add parameter to batch geocoder to choose query method

### DIFF
--- a/nesta/packages/geo_utils/geocode.py
+++ b/nesta/packages/geo_utils/geocode.py
@@ -102,7 +102,7 @@ def geocode_dataframe(df):
 
 def geocode_batch_dataframe(df, city='city', country='country',
                             latitude='latitude', longitude='longitude',
-                            query_method=2):
+                            query_method='both'):
     """Geocodes a dataframe, first by supplying the city and country to the api, if this
     fails a second attempt is made supplying the combination using the q= method.
     The supplied dataframe df is returned with additional columns appended, containing
@@ -114,23 +114,25 @@ def geocode_batch_dataframe(df, city='city', country='country',
         country (str): name of the input column containing the country
         latitude (str): name of the output column containing the latitude
         longitude (str): name of the output column containing the longitude
-        query_method (int): query methods to attempt: 0: city, country only
-                                                1: q only
-                                                2: city, country with fallback to q method
+        query_method (int): query methods to attempt:
+                                    'city_country_only': city and country only
+                                    'query_only': q method only
+                                    'both': city, country with fallback to q method
 
     Returns:
         (:obj:`pandas.DataFrame`): original dataframe with lat and lon appended as floats
     """
-    if query_method not in [0, 1, 2]:
-        raise ValueError("Invalid query method, must be 0, 1 or 2")
+
+    if query_method not in ['city_country_only', 'query_only', 'both']:
+        raise ValueError("Invalid query method, must be 'city_country_only', 'query_only' or 'both'")
 
     df[latitude], df[longitude] = None, None
 
     for idx, row in df.iterrows():
         location = None
-        if query_method in [0, 2]:
+        if query_method in ['city_country_only', 'both']:
             location = _geocode(city=row[city], country=row[country])
-        if location is None and query_method in [1, 2]:
+        if location is None and query_method in ['query_only', 'both']:
             query = f"{row[city]} {row[country]}"
             location = _geocode(q=query)
         if location is not None:

--- a/nesta/packages/geo_utils/tests/test_geotools.py
+++ b/nesta/packages/geo_utils/tests/test_geotools.py
@@ -200,7 +200,7 @@ class TestGeocodeBatchDataframe():
                           mock.call(city='Brussels', country='Belgium'),
                           mock.call(q='Brussels Belgium')]
 
-        geocoded_dataframe = geocode_batch_dataframe(test_dataframe, query_method=2)
+        geocoded_dataframe = geocode_batch_dataframe(test_dataframe, query_method='both')
 
         # Check expected behaviours
         assert_frame_equal(geocoded_dataframe, expected_dataframe,
@@ -226,7 +226,7 @@ class TestGeocodeBatchDataframe():
                           mock.call(q='Sheffield United Kingdom'),
                           mock.call(q='Brussels Belgium')]
 
-        geocoded_dataframe = geocode_batch_dataframe(test_dataframe, query_method=1)
+        geocoded_dataframe = geocode_batch_dataframe(test_dataframe, query_method='query_only')
 
         # Check expected behaviours
         assert_frame_equal(geocoded_dataframe, expected_dataframe,
@@ -238,13 +238,13 @@ class TestGeocodeBatchDataframe():
                                                                 mocked_geocode,
                                                                 test_dataframe):
         with pytest.raises(ValueError):
-            geocode_batch_dataframe(test_dataframe, query_method=3)
+            geocode_batch_dataframe(test_dataframe, query_method='cats')
 
         with pytest.raises(ValueError):
             geocode_batch_dataframe(test_dataframe, query_method='test')
 
         with pytest.raises(ValueError):
-            geocode_batch_dataframe(test_dataframe, query_method=None)
+            geocode_batch_dataframe(test_dataframe, query_method=1)
 
     @mock.patch(_GEOCODE)
     def test_output_column_names_are_applied(self, mocked_geocode, test_dataframe):

--- a/nesta/production/batchables/batchgeocode/run.py
+++ b/nesta/production/batchables/batchgeocode/run.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import pandas as pd
-import s3fs
+import s3fs  # not called but required import to read from s3://
 
 from nesta.packages.geo_utils.country_iso_code import country_iso_code_dataframe
 from nesta.packages.geo_utils.geocode import geocode_batch_dataframe
@@ -26,8 +26,8 @@ def run():
     df = country_iso_code_dataframe(df)
     logging.info("Country ISO codes appended")
 
-    # geocode, appending latitude and longitude columns
-    df = geocode_batch_dataframe(df)
+    # geocode, appending latitude and longitude columns, using the q= query method
+    df = geocode_batch_dataframe(df, query_method=1)
     logging.info("Geocoding complete")
 
     # remove city and country columns and append done column

--- a/nesta/production/batchables/batchgeocode/run.py
+++ b/nesta/production/batchables/batchgeocode/run.py
@@ -27,7 +27,7 @@ def run():
     logging.info("Country ISO codes appended")
 
     # geocode, appending latitude and longitude columns, using the q= query method
-    df = geocode_batch_dataframe(df, query_method=1)
+    df = geocode_batch_dataframe(df, query_method='query_only')
     logging.info("Geocoding complete")
 
     # remove city and country columns and append done column


### PR DESCRIPTION
There is now a flag enabling the query method to be chosen. I went with 0, 1, 2 as the options over string representations.

Tests added etc.

Geocoding using this method have been re-run and the results look promising: correct for Nottingham which was incorrect before and there are only ~500 which failed to geocode.

I foolishly truncated the table before re-running it rather than making a copy *facepalm* but it only took 10 hours to run so we can go back in less than a day :oO Kostas is going to have a look at the data when he can as he noticed the issue during his analysis.