### PR TITLE
Fix travis build issue causing test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - '3.6'
@@ -31,10 +32,3 @@ branches:
     - dev
 services:
   - mysql
-addons:
-  apt:
-    sources:
-      - mysql-5.7-trusty
-    packages:
-      - mysql-server
-      - mysql-client


### PR DESCRIPTION
It seems this issue has been intermittent for a while with people reporting it at various times during the last year or so. I tried a few things, like manually adding the key (horrible, glad I couldn't get this to work) but eventually settled on just upgrading the ubuntu version for the vm to Xenial.

mysql 5.7 is the default in this version so the build script is simplified.