### PR TITLE
Upgrade setuptools.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ s3fs==0.2.1
 scikit_learn==0.21.3
 scipy==1.2.2
 selenium==3.141.0
-setuptools==40.2.0
+setuptools==41.1.0
 SPARQLWrapper==1.8.4
 SQLAlchemy==1.3.4


### PR DESCRIPTION
Setup.py was failing with the previous version.

eurito_daps requirements breaks when the nesta repo is added, because of a conflict with setuptools. 

If the build passes I will just merge this 🚢 