### PR TITLE
Mag collection

### DIFF
--- a/nesta/core/orms/mag_orm.py
+++ b/nesta/core/orms/mag_orm.py
@@ -1,11 +1,13 @@
-'''
+"""
 Microsoft Academic Graph
 ========================
-'''
-from sqlalchemy import Column
+"""
+from sqlalchemy import Column, ForeignKey
 from sqlalchemy.dialects.mysql import VARCHAR, TEXT
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.types import BIGINT, INTEGER
+from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import BIGINT, INTEGER, DATE
 
 
 Base = declarative_base()
@@ -20,3 +22,67 @@ class FieldOfStudy(Base):
     level = Column(INTEGER)
     parent_ids = Column(TEXT)
     child_ids = Column(TEXT)
+
+
+class PaperFieldsOfStudy(Base):
+    __tablename__ = 'mag_paper_fields_of_study'
+
+    paper_id = Column(BIGINT,
+                      ForeignKey('mag_papers.id'),
+                      primary_key=True,
+                      autoincrement=False)
+    field_of_study_id = Column(BIGINT,
+                               ForeignKey('mag_fields_of_study.id'),
+                               primary_key=True,
+                               autoincrement=False)
+    paper = relationship('Paper', back_populates='fields_of_study')
+    field_of_study = relationship('FieldOfStudy')
+
+
+class PaperLanguage(Base):
+    __tablename__ = 'mag_paper_languages'
+
+    paper_id = Column(BIGINT, ForeignKey('mag_papers.id'), primary_key=True)
+    language = Column(VARCHAR(20), primary_key=True)
+
+
+class Paper(Base):
+    __tablename__ = 'mag_papers'
+
+    id = Column(BIGINT, primary_key=True, autoincrement=False)
+    title = Column(TEXT(collation='utf8_bin'))
+    citation_count = Column(INTEGER)
+    created_date = Column(DATE)
+    doi = Column(VARCHAR(200))
+    book_title = Column(VARCHAR(200))
+    _languages = relationship('PaperLanguage')
+    languages = association_proxy('_languages', 'language',
+                                  creator=lambda l: PaperLanguage(language=l))
+    fields_of_study = relationship('PaperFieldsOfStudy', back_populates='paper')
+    authors = relationship('PaperAuthor', back_populates='paper')
+
+
+class PaperAuthor(Base):
+    __tablename__ = 'mag_paper_authors'
+
+    paper_id = Column(BIGINT,
+                      ForeignKey('mag_papers.id'),
+                      primary_key=True,
+                      autoincrement=False)
+    author_id = Column(BIGINT,
+                       ForeignKey('mag_authors.id'),
+                       primary_key=True,
+                       autoincrement=False)
+    paper = relationship('Paper', back_populates='authors')
+    author = relationship('Author', back_populates='papers')
+
+
+class Author(Base):
+    __tablename__ = 'mag_authors'
+
+    id = Column(BIGINT, primary_key=True, autoincrement=False)
+    name = Column(VARCHAR(100, collation='utf8_bin'))
+    # the foreign key constraint and relationship to grid_institutes is omitted here
+    # as the datasets could be collected at different times
+    grid_id = Column(VARCHAR(20))
+    papers = relationship('PaperAuthor', back_populates='author')

--- a/nesta/core/routines/arxiv/arxiv_mag_sparql_task.py
+++ b/nesta/core/routines/arxiv/arxiv_mag_sparql_task.py
@@ -146,7 +146,8 @@ class MagSparqlTask(luigi.Task):
                 missing_fos_ids = row['fields_of_study'] - found_fos_ids
                 if missing_fos_ids:
                     logging.info(f"Missing field of study ids: {missing_fos_ids}")
-                    fos_not_found = update_field_of_study_ids_sparql(session, missing_fos_ids)
+                    fos_not_found = update_field_of_study_ids_sparql(self.engine,
+                                                                     missing_fos_ids)
                     # any fos not found in mag are removed to prevent foreign key
                     # constraint errors when building the link table
                     for fos in fos_not_found:

--- a/nesta/core/routines/mag/mag_collect_task.py
+++ b/nesta/core/routines/mag/mag_collect_task.py
@@ -1,0 +1,197 @@
+"""
+MAG data collection and processing
+==================================
+
+Luigi pipeline to collect all data from the MAG SPARQL endpoint and load it to SQL.
+"""
+import boto3
+from botocore.exceptions import ClientError
+import json
+import luigi
+import logging
+
+from nesta.packages.mag.query_mag_sparql import (check_institute_exists,
+                                                 get_eu_countries,
+                                                 query_by_grid_id,
+                                                 update_field_of_study_ids_sparql)
+from nesta.packages.misc_utils.batches import split_batches
+from nesta.core.orms.mag_orm import (Base, Paper, Author, PaperAuthor,
+                                     PaperFieldsOfStudy, FieldOfStudy, PaperLanguage)
+from nesta.core.orms.grid_orm import Institute
+from nesta.core.orms.orm_utils import get_mysql_engine, db_session, insert_data
+from nesta.core.luigihacks import misctools
+from nesta.core.luigihacks.mysqldb import MySqlTarget
+
+
+BUCKET = "nesta-production-intermediate"
+INTERMEDIATE_FILE = "mag-collection-completed-institutes.json"
+
+
+class MagCollectSparqlTask(luigi.Task):
+    """Query MAG for Papers, and Authors who are affiliated with EU institutes.
+
+    Args:
+        date (datetime): Datetime used to label the outputs
+        _routine_id (str): String used to label the AWS task
+        db_config_env (str): environmental variable pointing to the db config file
+        db_config_path (str): The output database configuration
+        mag_config_path (str): Microsoft Academic Graph Api key configuration path
+        insert_batch_size (int): number of records to insert into the database at once
+                                 (not used in this task but passed down to others)
+        articles_from_date (str): new and updated articles from this date will be
+                                  retrieved. Must be in YYYY-MM-DD format
+                                  (not used in this task but passed down to others)
+    """
+    date = luigi.DateParameter()
+    _routine_id = luigi.Parameter()
+    test = luigi.BoolParameter(default=True)
+    db_config_env = luigi.Parameter()
+    db_config_path = luigi.Parameter()
+    batch_size = luigi.IntParameter()
+    insert_batch_size = luigi.IntParameter()
+    from_date = luigi.Parameter()
+    min_citations = luigi.IntParameter()
+
+    def output(self):
+        '''Points to the output database engine'''
+        db_config = misctools.get_config(self.db_config_path, "mysqldb")
+        db_config["database"] = 'dev' if self.test else 'production'
+        db_config["table"] = "MAG <dummy>"  # Note, not a real table
+        update_id = "MagCollectSparql_{}".format(self.date)
+        return MySqlTarget(update_id=update_id, **db_config)
+
+    def run(self):
+        # s3 setup
+        s3 = boto3.resource('s3')
+        intermediate_file = s3.Object(BUCKET, INTERMEDIATE_FILE)
+
+        # database setup
+        database = 'dev' if self.test else 'production'
+        logging.info(f"Using {database} database")
+        self.engine = get_mysql_engine(self.db_config_env, 'mysqldb', database)
+        Base.metadata.create_all(self.engine)
+
+        eu = get_eu_countries()
+        logging.info(f"Retrieved {len(eu)} EU countries")
+
+        with db_session(self.engine) as session:
+            all_fos_ids = {f.id for f in (session
+                                          .query(FieldOfStudy.id)
+                                          .all())}
+            logging.info(f"{len(all_fos_ids):,} fields of study in database")
+
+            eu_grid_ids = {i.id for i in (session
+                                          .query(Institute.id)
+                                          .filter(Institute.country.in_(eu))
+                                          .all())}
+            logging.info(f"{len(eu_grid_ids):,} EU institutes in GRID")
+
+        try:
+            processed_grid_ids = set(json.loads(intermediate_file
+                                                .get()['Body']
+                                                ._raw_stream.read()))
+
+            logging.info(f"{len(processed_grid_ids)} previously processed institutes")
+            eu_grid_ids = eu_grid_ids - processed_grid_ids
+            logging.info(f"{len(eu_grid_ids):,} institutes to process")
+        except ClientError:
+            logging.info("Unable to load file of processed institutes, starting from scratch")
+            processed_grid_ids = set()
+
+        if self.test:
+            self.batch_size = 500
+            batch_limit = 1
+        else:
+            batch_limit = None
+        testing_finished = False
+
+        row_count = 0
+        for institute_count, grid_id in enumerate(eu_grid_ids):
+            paper_ids, author_ids = set(), set()
+            data = {Paper: [],
+                    Author: [],
+                    PaperAuthor: set(),
+                    PaperFieldsOfStudy: set(),
+                    PaperLanguage: set()}
+
+            if not institute_count % 50:
+                logging.info(f"{institute_count:,} of {len(eu_grid_ids):,} institutes processed")
+
+            if not check_institute_exists(grid_id):
+                logging.debug(f"{grid_id} not found in MAG")
+                continue
+
+            # these tables have data stored in sets for deduping so the fieldnames will
+            # need to be added when converting to a list of dicts for loading to the db
+            field_names_to_add = {PaperAuthor: ('paper_id', 'author_id'),
+                                  PaperFieldsOfStudy: ('paper_id', 'field_of_study_id'),
+                                  PaperLanguage: ('paper_id', 'language')}
+
+            logging.info(f"Querying MAG for {grid_id}")
+            for row in query_by_grid_id(grid_id,
+                                        from_date=self.from_date,
+                                        min_citations=self.min_citations,
+                                        batch_size=self.batch_size,
+                                        batch_limit=batch_limit):
+
+                fos_id = row['fieldOfStudyId']
+                if fos_id not in all_fos_ids:
+                    logging.info(f"Getting missing field of study {fos_id} from MAG")
+                    update_field_of_study_ids_sparql(self.engine, fos_ids=[fos_id])
+                    all_fos_ids.add(fos_id)
+
+                # the returned data is normalised and therefore contains many duplicates
+                paper_id = row['paperId']
+                if paper_id not in paper_ids:
+                    data[Paper].append({'id': paper_id,
+                                        'title': row['paperTitle'],
+                                        'citation_count': row['paperCitationCount'],
+                                        'created_date': row['paperCreatedDate'],
+                                        'doi': row.get('paperDoi'),
+                                        'book_title': row.get('bookTitle')})
+                    paper_ids.add(paper_id)
+
+                author_id = row['authorId']
+                if author_id not in author_ids:
+                    data[Author].append({'id': author_id,
+                                         'name': row['authorName'],
+                                         'grid_id': grid_id})
+                    author_ids.add(author_id)
+
+                data[PaperAuthor].add((row['paperId'], row['authorId']))
+
+                data[PaperFieldsOfStudy].add((row['paperId'], row['fieldOfStudyId']))
+
+                try:
+                    data[PaperLanguage].add((row['paperId'], row['paperLanguage']))
+                except KeyError:
+                    # language is an optional field
+                    pass
+
+                row_count += 1
+                if self.test and row_count >= 1000:
+                    logging.warning("Breaking after 1000 rows in test mode")
+                    testing_finished = True
+                    break
+
+            # write out to SQL
+            for table, rows in data.items():
+                if table in field_names_to_add:
+                    rows = [{k: v for k, v in zip(field_names_to_add[table], row)}
+                            for row in rows]
+                logging.debug(f"Writing {len(rows):,} rows to {table.__table__.name}")
+
+                for batch in split_batches(rows, self.insert_batch_size):
+                    insert_data('MYSQLDB', 'mysqldb', database, Base, table, batch)
+
+            # flag institute as completed on S3
+            processed_grid_ids.add(grid_id)
+            intermediate_file.put(Body=json.dumps(list(processed_grid_ids)))
+
+            if testing_finished:
+                break
+
+
+        # mark as done
+        logging.info("Task complete")
+        self.output().touch()

--- a/nesta/core/routines/mag/mag_estimate_root_task.py
+++ b/nesta/core/routines/mag/mag_estimate_root_task.py
@@ -1,0 +1,38 @@
+"""
+MAG data collection and processing
+==================================
+
+Luigi pipeline to collect all data from the MAG SPARQL endpoint and load it to SQL.
+"""
+import luigi
+import datetime
+import logging
+
+from nesta.core.routines.mag.mag_estimate_task import MagEstimateSparqlTask
+
+
+class RootTask(luigi.WrapperTask):
+    '''A dummy root task, which collects the database configurations
+    and executes the central task.
+
+    Args:
+        date (datetime): Date used to label the outputs
+        db_config_path (str): Path to the MySQL database configuration
+        production (bool): Flag indicating whether running in testing
+                           mode (False, default), or production mode (True).
+    '''
+    date = luigi.DateParameter(default=datetime.date.today())
+    db_config_path = luigi.Parameter(default="mysqldb.config")
+    production = luigi.BoolParameter(default=False)
+
+    def requires(self):
+        '''Collects the database configurations
+        and executes the central task.'''
+        _routine_id = "{}-{}".format(self.date, self.production)
+
+        logging.getLogger().setLevel(logging.INFO)
+        yield MagEstimateSparqlTask(date=self.date,
+                                    _routine_id=_routine_id,
+                                    db_config_path=self.db_config_path,
+                                    db_config_env='MYSQLDB',
+                                    test=(not self.production))

--- a/nesta/core/routines/mag/mag_estimate_task.py
+++ b/nesta/core/routines/mag/mag_estimate_task.py
@@ -1,0 +1,101 @@
+"""
+MAG data collection and processing
+==================================
+
+Luigi pipeline to collect all data from the MAG SPARQL endpoint and load it to SQL.
+"""
+import boto3
+from botocore.exceptions import ClientError
+import json
+import luigi
+import logging
+
+from nesta.packages.mag.query_mag_sparql import count_papers, get_eu_countries
+from nesta.core.orms.grid_orm import Institute
+from nesta.core.orms.orm_utils import get_mysql_engine, db_session
+from nesta.core.luigihacks import misctools
+from nesta.core.luigihacks.mysqldb import MySqlTarget
+
+
+BUCKET = "nesta-production-intermediate"
+MAG_ENDPOINT = 'http://ma-graph.org/sparql'
+
+
+class MagEstimateSparqlTask(luigi.Task):
+    """Query MAG for Papers, and Authors who are affiliated with EU institutes.
+
+    Args:
+        date (datetime): Datetime used to label the outputs
+        _routine_id (str): String used to label the AWS task
+        db_config_env (str): environmental variable pointing to the db config file
+        db_config_path (str): The output database configuration
+        mag_config_path (str): Microsoft Academic Graph Api key configuration path
+        insert_batch_size (int): number of records to insert into the database at once
+                                 (not used in this task but passed down to others)
+        articles_from_date (str): new and updated articles from this date will be
+                                  retrieved. Must be in YYYY-MM-DD format
+                                  (not used in this task but passed down to others)
+    """
+    date = luigi.DateParameter()
+    _routine_id = luigi.Parameter()
+    test = luigi.BoolParameter(default=True)
+    db_config_env = luigi.Parameter()
+    db_config_path = luigi.Parameter()
+
+    def output(self):
+        '''Points to the output database engine'''
+        db_config = misctools.get_config(self.db_config_path, "mysqldb")
+        db_config["database"] = 'dev' if self.test else 'production'
+        db_config["table"] = "MAG <dummy>"  # Note, not a real table
+        update_id = "MagCollectSparql_{}".format(self.date)
+        return MySqlTarget(update_id=update_id, **db_config)
+
+    def run(self):
+        # database setup
+        database = 'dev' if self.test else 'production'
+        logging.info(f"Using {database} database")
+        self.engine = get_mysql_engine(self.db_config_env, 'mysqldb', database)
+
+        # s3 setup
+        s3 = boto3.resource('s3')
+        intermediate_file = s3.Object(BUCKET, f"mag_estimate_{database}.json")
+
+        eu = get_eu_countries()
+
+        with db_session(self.engine) as session:
+            eu_grid_ids = {i.id for i in (session
+                                          .query(Institute.id)
+                                          .filter(Institute.country.in_(eu))
+                                          .all())}
+            logging.info(f"{len(eu_grid_ids):,} EU institutes in GRID")
+
+        # collect previous and exclude
+        try:
+            previous = json.loads(intermediate_file.get()['Body']._raw_stream.read())
+
+            done_institutes = set(previous['institutes'])
+            logging.info(f"{len(done_institutes)} previously processed institutes retrieved")
+            eu_grid_ids = eu_grid_ids - done_institutes
+            logging.info(f"{len(eu_grid_ids)} to process")
+
+            paper_ids = set(previous['paper_ids'])
+            logging.info(f"{len(paper_ids)} previously processed papers retrieved")
+        except ClientError:
+            logging.info("Unable to load previous file, starting from scratch")
+            done_institutes = set()
+            paper_ids = set()
+
+        limit = 100 if self.test else None
+        save_every = 50 if self.test else 1000000
+
+        total = count_papers(eu_grid_ids,
+                             done_institutes,
+                             paper_ids,
+                             intermediate_file,
+                             save_every=save_every,
+                             limit=limit)
+
+        # mark as done
+        logging.info("Task complete")
+        logging.info(f"Total EU papers found: {total:,}")
+        self.output().touch()

--- a/nesta/core/routines/mag/mag_root_task.py
+++ b/nesta/core/routines/mag/mag_root_task.py
@@ -1,0 +1,46 @@
+"""
+MAG data collection and processing
+==================================
+
+Luigi pipeline to collect all data from the MAG SPARQL endpoint and load it to SQL.
+"""
+import luigi
+import datetime
+import logging
+
+from nesta.core.routines.mag.mag_collect_task import MagCollectSparqlTask
+
+
+class RootTask(luigi.WrapperTask):
+    '''A dummy root task, which collects the database configurations
+    and executes the central task.
+
+    Args:
+        date (datetime): Date used to label the outputs
+        db_config_path (str): Path to the MySQL database configuration
+        production (bool): Flag indicating whether running in testing
+                           mode (False, default), or production mode (True).
+    '''
+    date = luigi.DateParameter(default=datetime.date.today())
+    db_config_path = luigi.Parameter(default="mysqldb.config")
+    production = luigi.BoolParameter(default=False)
+    batch_size = luigi.IntParameter(default=5000)
+    insert_batch_size = luigi.IntParameter(default=500)
+    from_date = luigi.Parameter(default='2000-01-01')
+    min_citations = luigi.IntParameter(default=1)
+
+    def requires(self):
+        '''Collects the database configurations
+        and executes the central task.'''
+        _routine_id = "{}-{}".format(self.date, self.production)
+
+        logging.getLogger().setLevel(logging.INFO)
+        yield MagCollectSparqlTask(date=self.date,
+                                   _routine_id=_routine_id,
+                                   db_config_path=self.db_config_path,
+                                   db_config_env='MYSQLDB',
+                                   test=not self.production,
+                                   batch_size=self.batch_size,
+                                   insert_batch_size=self.insert_batch_size,
+                                   from_date=self.from_date,
+                                   min_citations=self.min_citations)

--- a/nesta/packages/mag/query_mag_sparql.py
+++ b/nesta/packages/mag/query_mag_sparql.py
@@ -1,7 +1,10 @@
+from bs4 import BeautifulSoup
 from collections import defaultdict
 from jellyfish import levenshtein_distance
+import json
 import logging
 import re
+import requests
 
 from nesta.packages.misc_utils.batches import split_batches
 from nesta.packages.misc_utils.sparql_query import sparql_query
@@ -22,8 +25,8 @@ def _batch_query_articles_by_doi(query, articles, batch_size=10):
             Must contatin at least `id` and `doi` in each dict.
         batch_size (int): number of ids to query in a batch. Max size = 50
 
-    Returns:
-        (:obj:`list` of :obj:`dict`): yields batches of data returned from MAG
+    Yields:
+        (:obj:`list` of :obj:`dict`): batches of data returned from MAG
     """
     if not 1 <= batch_size <= 10:  # max limit for uri length
         raise ValueError("batch_size must be between 1 and 10")
@@ -49,8 +52,8 @@ def query_articles_by_doi(articles):
         articles (:obj:`list` of :obj:`dict`): articles to query in MAG.
             Must contatin at least `id` and `doi` in each dict.
 
-    Returns:
-        (:obj:`list` of :obj:`dict`): data returned from MAG
+    Yields:
+        (dict): single article
     """
     query = '''
     PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -106,7 +109,38 @@ def query_articles_by_doi(articles):
             yield best_match
 
 
-def _batch_query_sparql(query, concat_format=None, filter_on=None, ids=None, batch_size=50):
+def _batched_entity_filter(concat_format, filter_on, ids, batch_size):
+    """Creates batches of entity filters for SPARQL queries. Constructing a
+    'filter in' statement using the provided ids, splitting whenever the batch size is
+    hit.
+
+    A call with the following arguments:
+        _batched_entity_filter('<http://ma-graph.org/entity/{}>', 'data', [1, 2], 50)
+
+    Will return a generator which yields the following:
+        "FILTER (?data IN (<http://ma-graph.org/entity/1>,<http://ma-graph.org/entity/2>))"
+
+    Args:
+        concat_format (str): string format to be applied when concatenating ids
+            requires a placeholder for id {}
+        filter_on (str): name of the field to use in the filter. The '?' prefix
+            is not required
+        ids (list): If ids are supplied they are queried as batches, otherwise
+            all entities are queried
+        batch_size (int): number of ids to query in a batch.
+
+    Yields:
+        (str): filter string containing ids up to the chosen batch size
+    """
+    for batch_of_ids in split_batches(ids, batch_size):
+        entities = ','.join(concat_format.format(i) for i in batch_of_ids)
+
+        yield f"FILTER (?{filter_on} IN ({entities}))"
+
+
+def _batch_query_sparql(query,
+                        concat_format=None, filter_on=None, ids=None,
+                        batch_size=50):
     """Manages batching of sparql queries, with filtering and yielding of single rows
     mag via the sparql api.
 
@@ -114,29 +148,31 @@ def _batch_query_sparql(query, concat_format=None, filter_on=None, ids=None, bat
         query (str): sparql query containing a format string placeholder {}
         concat_format (str): string format to be applied when concatenating ids
             requires a placeholder for id {}
-        filter_on (str): name of the field to use in the filter (no '?' required)
+        filter_on (str): name of the field to use in the filter. The '?' prefix
+            is not required
         ids (list): If ids are supplied they are queried as batches, otherwise
             all entities are queried
         batch_size (int): number of ids to query in a batch. Maximum = 50
 
-    Returns:
-        (dict): single rows of returned data are yielded
+    Yields:
+        (dict): single row of returned data
     """
     if not 1 <= batch_size <= 50:  # max limit for uri length
         raise ValueError("batch_size must be between 1 and 50")
 
     if all([concat_format, filter_on, ids]):
-        for batch_of_ids in split_batches(ids, batch_size):
-            entities = ','.join(concat_format.format(i) for i in batch_of_ids)
-            entity_filter = f"FILTER (?{filter_on} IN ({entities}))"
+        entity_filters = _batched_entity_filter(concat_format, filter_on, ids,
+                                                batch_size)
     elif any([concat_format, filter_on, ids]):
-        raise ValueError("concat_format, filter_on and ids must all be supplied together or not at all")
+        raise ValueError("concat_format, filter_on and ids must all be supplied "
+                         "together or not at all")
     else:
-        # retrieve all fields of study
-        entity_filter = ''
+        # retrieve all
+        entity_filters = ['']
 
-    for batch in sparql_query(MAG_ENDPOINT, query.format(entity_filter)):
-        yield from batch
+    for entity_filter in entity_filters:
+        for batch in sparql_query(MAG_ENDPOINT, query.format(entity_filter)):
+            yield from batch
 
 
 def extract_entity_id(entity):
@@ -166,7 +202,7 @@ def query_fields_of_study_sparql(ids=None, results_limit=None):
                                      all are returned if None
         results_limit (int): limit the number of results returned (for testing)
 
-    Returns:
+    Yields:
         (dict): processed field of study
     """
     query = '''
@@ -240,7 +276,7 @@ def update_field_of_study_ids_sparql(engine, fos_ids):
                          for fos in query_fields_of_study_sparql(fos_ids)]
 
     logging.info(f"Retrieved {len(new_fos_to_import)} new fields of study from MAG")
-    fos_not_found = fos_ids - {fos.id for fos in new_fos_to_import}
+    fos_not_found = set(fos_ids) - {fos.id for fos in new_fos_to_import}
     if fos_not_found:
         logging.warning(f"Fields of study present in articles but could not be found in MAG Fields of Study database: {fos_not_found}")
     with db_session(engine) as session:
@@ -257,8 +293,8 @@ def query_authors(ids=None, results_limit=None):
         ids: (:obj:`list` of `int`): author ids to query, all are returned if None
         results_limit (int): limit the number of results returned (for testing)
 
-    Returns:
-        (dict): yields a single author at a time, with affiliation
+    Yields:
+        (dict): a single author with affiliation
     """
     query = '''
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -308,6 +344,181 @@ def query_authors(ids=None, results_limit=None):
         if results_limit is not None and count >= results_limit:
             logging.warning(f"Breaking after {results_limit} for testing")
             break
+
+
+def check_institute_exists(grid_id):
+    query = '''
+    PREFIX magc: <http://ma-graph.org/class/>
+    PREFIX magp: <http://ma-graph.org/property/>
+
+    SELECT ?affiliationId
+
+    WHERE {{
+    ?affiliationId rdf:type magc:Affiliation .
+    ?affiliationId magp:grid ?affiliationGridId .
+
+    FILTER (?affiliationGridId = <http://www.grid.ac/institutes/{grid_id}>)
+    }}
+    '''
+    logging.debug(f"Checking {grid_id} exists in MAG")
+    return list(sparql_query(MAG_ENDPOINT, query.format(grid_id=grid_id))) != []
+
+
+def query_by_grid_id(grid_id, from_date='2000-01-01', min_citations=1,
+                     batch_size=5000, batch_limit=None):
+    """Queries the MAG for authors, papers, fields of study from a grid id.
+
+    Args:
+        ids: (:obj:`list` of `int`): author ids to query, all are returned if None
+        from_date (str): minimum date for paper created date in YYYY-MM-DD format
+        min_citations (int): minimum number of citations a paper has received
+        batch_size (int): number of rows to retrieve when batching calls to MAG
+        results_limit (int): limit the number of results returned, for testing
+
+    Yields:
+        (dict): yields a row of returned data
+    """
+    query = '''
+    PREFIX magc: <http://ma-graph.org/class/>
+    PREFIX grid: <http://www.grid.ac/institutes>
+    PREFIX magp: <http://ma-graph.org/property/>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX datacite: <http://purl.org/spar/datacite/>
+    PREFIX fabio: <http://purl.org/spar/fabio/>
+
+    SELECT
+        ?authorId
+        ?authorName
+        ?paperId
+        ?paperTitle
+        ?paperCitationCount
+        ?paperCreatedDate
+        ?paperDoi
+        ?paperLanguage
+        ?bookTitle
+        ?fieldOfStudyId
+
+    WHERE {{
+        ?affiliationId rdf:type magc:Affiliation .
+        ?affiliationId magp:grid ?affiliationGridId .
+        ?authorId org:memberOf ?affiliationId .
+        ?authorId foaf:name ?authorName .
+        ?paperId dcterms:creator ?authorId .
+        ?paperId dcterms:title ?paperTitle .
+        ?paperId magp:citationCount ?paperCitationCount .
+        ?paperId dcterms:created ?paperCreatedDate .
+        OPTIONAL {{?paperId datacite:doi ?paperDoi .}}
+        OPTIONAL {{?paperId dcterms:language ?paperLanguage .}}
+        OPTIONAL {{?paperId magp:bookTitle ?bookTitle .}}
+        ?paperId fabio:hasDiscipline ?fieldOfStudyId .
+
+        FILTER (?paperCreatedDate >= "{from_date}"^^xsd:date)
+        FILTER (?paperCitationCount >= {min_citations})
+        FILTER (?affiliationGridId = <http://www.grid.ac/institutes/{grid_id}>)
+    }}
+    '''
+    logging.debug(f"Querying MAG for institute {grid_id}")
+
+    for batch in (sparql_query(MAG_ENDPOINT,
+                               nbatch=batch_size,
+                               batch_limit=batch_limit,
+                               query=query.format(grid_id=grid_id,
+                                                  from_date=from_date,
+                                                  min_citations=min_citations))):
+        for row in batch:
+            # extract any of ids
+            yield {k: extract_entity_id(v) if k.endswith('Id') else v
+                   for k, v in row.items()}
+
+
+def batch_query_papers_by_institute_id(query):
+    """Queries MAG for a batch and yields a row of data at a time.
+
+    Args:
+        query(str): SPARQL query
+
+    Yields:
+        (dict): row of data
+    """
+    for batch in sparql_query(MAG_ENDPOINT, query):
+        yield from batch
+
+def count_papers(institutes, done_institutes, paper_ids, intermediate_file,
+                 save_every=1000000, limit=None):
+    """Count the number of papers produced from a list of supplied institues.
+
+    Args:
+        institutes(list): GRID IDs of the institutes to look up
+        done_institutes(list): GRID IDs of institues which have already been processed
+        paper_ids(list): MAG IDs of papers which have already been processed
+        intermediate_file(:obj:`boto3.resources.s3.object`): file to store processed
+        institutes and paper ids
+        save_every(int): saves to s3 each time this number of papers are found
+        limit(int): break at this number of processed records, for testing
+
+    Returns:
+        (int): total number of papers found
+    """
+    query = '''
+    PREFIX magp: <http://ma-graph.org/property/>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+
+    SELECT ?paperId
+
+    WHERE {{
+    ?affiliationId magp:grid <http://www.grid.ac/institutes/{}> .
+    ?authorId org:memberOf ?affiliationId .
+    ?paperId dcterms:creator ?authorId .
+    }}
+    '''
+    count = 0
+    for institute in institutes:
+        for row in batch_query_papers_by_institute_id(query.format(institute)):
+            count += 1
+            logging.debug(row)
+            paper_id = extract_entity_id(row['paperId'])
+            if paper_id in paper_ids:
+                continue
+            paper_ids.add(paper_id)
+            total = len(paper_ids)
+            if not total % 1000:
+                logging.info(f"{total:,} EU papers found")
+
+            if not total % save_every:
+                # write out to file on S3 for safekeeping
+                logging.info("Writing out to file with "
+                             f"{len(done_institutes)} institutes "
+                             f"and {total} papers")
+                intermediate_file.put(Body=json.dumps({'paper_ids': list(paper_ids),
+                                                       'institutes': list(done_institutes)}))
+
+            if limit is not None and count >= limit:
+                logging.warning(f"Breaking after {limit} papers in test mode")
+                return limit
+
+        done_institutes.add(institute)
+
+    return len(paper_ids)
+
+
+def get_eu_countries():
+    """Retrieves names of EU countries from online service and parses them.
+
+    Returns:
+        (:obj:`list` of :obj:`str`): names of all the countries in the EU
+    """
+    country_endpoint = "https://europa.eu/european-union/about-eu/countries_en"
+
+    response = requests.get(country_endpoint)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, features='lxml')
+    table = soup.find(id='year-entry2')
+
+    return [country.string for country in table.find_all('a')]
 
 
 if __name__ == "__main__":

--- a/nesta/packages/mag/tests/test_query_mag.py
+++ b/nesta/packages/mag/tests/test_query_mag.py
@@ -7,6 +7,10 @@ from nesta.packages.mag.query_mag_api import query_mag_api
 from nesta.packages.mag.query_mag_api import dedupe_entities
 from nesta.packages.mag.query_mag_sparql import extract_entity_id
 from nesta.packages.mag.query_mag_sparql import query_articles_by_doi
+from nesta.packages.mag.query_mag_sparql import _batch_query_sparql
+from nesta.packages.mag.query_mag_sparql import _batched_entity_filter
+from nesta.packages.mag.query_mag_sparql import MAG_ENDPOINT
+from nesta.packages.mag.query_mag_sparql import get_eu_countries
 
 
 class TestPrepareTitle:
@@ -94,7 +98,6 @@ class TestQueryArticles:
         assert result == [{'paperTitle': 'title_aa', 'score': 1, 'id': 1, 'doi': '1.1/1234'},
                           {'paperTitle': 'title_b', 'score': 0, 'id': 2, 'doi': '2.2/4321'}]
 
-
     @mock.patch('nesta.packages.mag.query_mag_sparql._batch_query_articles_by_doi', autospec=True)
     @mock.patch('nesta.packages.mag.query_mag_sparql.levenshtein_distance', autospec=True)
     def test_query_articles_by_doi_returns_no_results_when_doi_not_found(self,
@@ -111,3 +114,165 @@ class TestQueryArticles:
 
         result = list(query_articles_by_doi(missing_articles))
         assert result == [{'paperTitle': 'title_aa', 'score': 1, 'id': 1, 'doi': '1.1/1234'}]
+
+
+class TestBatchQuerySparql:
+    @mock.patch('nesta.packages.mag.query_mag_sparql._batched_entity_filter', autospec=True)
+    @mock.patch('nesta.packages.mag.query_mag_sparql.sparql_query', autospec=True)
+    def test_batch_query_sparql_raises_if_batch_size_invalid(self,
+                                                             mocked_sparql_query,
+                                                             mocked_entity_filter):
+        batch_size_error = "batch_size must be between 1 and 50"
+
+        with pytest.raises(ValueError) as e:
+            list(_batch_query_sparql('test_query', batch_size=51))
+        assert str(e.value) == batch_size_error
+        mocked_sparql_query.assert_not_called()
+        mocked_entity_filter.assert_not_called()
+
+        with pytest.raises(ValueError) as e:
+            list(_batch_query_sparql('test_query', batch_size=0))
+        assert str(e.value) == batch_size_error
+        mocked_sparql_query.assert_not_called()
+        mocked_entity_filter.assert_not_called()
+
+    @mock.patch('nesta.packages.mag.query_mag_sparql._batched_entity_filter', autospec=True)
+    @mock.patch('nesta.packages.mag.query_mag_sparql.sparql_query', autospec=True)
+    def test_batch_query_sparql_raises_if_wrong_arguments_provided(self,
+                                                                   mocked_sparql_query,
+                                                                   mocked_entity_filter):
+        argument_error = ("concat_format, filter_on and ids must all "
+                          "be supplied together or not at all")
+
+        with pytest.raises(ValueError) as e:
+            list(_batch_query_sparql('test_query', concat_format='concat_format'))
+        assert str(e.value) == argument_error
+        mocked_sparql_query.assert_not_called()
+        mocked_entity_filter.assert_not_called()
+
+        with pytest.raises(ValueError) as e:
+            list(_batch_query_sparql('test_query', filter_on='filter'))
+        assert str(e.value) == argument_error
+        mocked_sparql_query.assert_not_called()
+        mocked_entity_filter.assert_not_called()
+
+        with pytest.raises(ValueError) as e:
+            list(_batch_query_sparql('test_query', ids=['id1', 'id2']))
+        assert str(e.value) == argument_error
+        mocked_sparql_query.assert_not_called()
+        mocked_entity_filter.assert_not_called()
+
+    @mock.patch('nesta.packages.mag.query_mag_sparql._batched_entity_filter', autospec=True)
+    @mock.patch('nesta.packages.mag.query_mag_sparql.sparql_query', autospec=True)
+    def test_batch_query_sparql_queries_all_if_no_filtering_provided(self,
+                                                                     mocked_sparql_query,
+                                                                     mocked_entity_filter):
+        mocked_sparql_query.return_value = iter([[1, 2, 3], [4, 5, 6], [7]])
+        query = "SELECT ?somefield WHERE ?data graph:node ?somefield {}"
+
+        result = list(_batch_query_sparql(query))
+
+        assert result == [1, 2, 3, 4, 5, 6, 7]
+        mocked_sparql_query.assert_called_once_with(
+            MAG_ENDPOINT,
+            "SELECT ?somefield WHERE ?data graph:node ?somefield "
+        )
+        mocked_entity_filter.assert_not_called()
+
+    @mock.patch('nesta.packages.mag.query_mag_sparql._batched_entity_filter', autospec=True)
+    @mock.patch('nesta.packages.mag.query_mag_sparql.sparql_query', autospec=True)
+    def test_batch_query_sparql_limits_query_if_filtering_provided(self,
+                                                                   mocked_sparql_query,
+                                                                   mocked_entity_filter):
+        mocked_sparql_query.return_value = iter(['a', 'b', 'c'])
+        mocked_entity_filter.return_value = iter(["FILTER (?data IN (<1>,<2>,<3>))"])
+        query = "SELECT ?somefield WHERE ?data graph:node ?somefield {}"
+        concat_format = '<{}>'
+        filter_on = 'data'
+        ids = [1, 2, 3]
+        batch_size = 50
+
+        result = list(_batch_query_sparql(query, concat_format, filter_on, ids,
+                                          batch_size))
+
+        assert result == ['a', 'b', 'c']
+        mocked_entity_filter.assert_called_once_with(concat_format, filter_on, ids,
+                                                     batch_size)
+        mocked_sparql_query.assert_called_once_with(
+            MAG_ENDPOINT, ("SELECT ?somefield WHERE ?data graph:node "
+                           "?somefield FILTER (?data IN (<1>,<2>,<3>))"))
+
+    @mock.patch('nesta.packages.mag.query_mag_sparql._batched_entity_filter', autospec=True)
+    @mock.patch('nesta.packages.mag.query_mag_sparql.sparql_query', autospec=True)
+    def test_batch_query_sparql_splits_batches_of_ids(self,
+                                                      mocked_sparql_query,
+                                                      mocked_entity_filter):
+        mocked_sparql_query.side_effect = iter([['a', 'b'], ['c']])
+        mocked_entity_filter.return_value = iter(["FILTER (?data IN (<1>,<2>))",
+                                                 "FILTER (?data IN (<3>))"])
+        query = "SELECT ?somefield WHERE ?data graph:node ?somefield {}"
+        concat_format = '<{}>'
+        filter_on = 'data'
+        ids = [1, 2, 3]
+        batch_size = 2
+
+        result = list(_batch_query_sparql(query, concat_format, filter_on, ids,
+                                          batch_size))
+
+        assert result == ['a', 'b', 'c']
+        assert mocked_sparql_query.mock_calls == [
+            mock.call(MAG_ENDPOINT, ("SELECT ?somefield WHERE ?data graph:node "
+                                     "?somefield FILTER (?data IN (<1>,<2>))")),
+            mock.call(MAG_ENDPOINT, ("SELECT ?somefield WHERE ?data graph:node "
+                                     "?somefield FILTER (?data IN (<3>))"))]
+        mocked_entity_filter.assert_called_once_with(concat_format, filter_on, ids,
+                                                     batch_size)
+
+
+class TestBatchedEntityFilter:
+    @mock.patch('nesta.packages.mag.query_mag_sparql.split_batches', autospec=True)
+    def test_batched_entity_filter_constructs_correct_format(self,
+                                                             mocked_split_batches):
+        concat_format = '<{}>'
+        filter_on = 'data'
+        ids = [1, 2, 3]
+        batch_size = 50
+        mocked_split_batches.return_value = iter([[1, 2, 3]])
+
+        result = list(_batched_entity_filter(concat_format, filter_on, ids,
+                                             batch_size))
+
+        assert result == ["FILTER (?data IN (<1>,<2>,<3>))"]
+        mocked_split_batches.assert_called_once_with(ids, batch_size)
+
+    @mock.patch('nesta.packages.mag.query_mag_sparql.split_batches', autospec=True)
+    def test_batched_entity_filter_splits_batches_of_ids(self, mocked_split_batches):
+        concat_format = '<{}>'
+        filter_on = 'data'
+        ids = [1, 2, 3]
+        batch_size = 2
+        mocked_split_batches.return_value = iter([[1, 2], [3]])
+
+        result = list(_batched_entity_filter(concat_format, filter_on, ids,
+                                             batch_size))
+
+        assert result == ["FILTER (?data IN (<1>,<2>))",
+                          "FILTER (?data IN (<3>))"]
+        mocked_split_batches.assert_called_once_with(ids, batch_size)
+
+
+@mock.patch('nesta.packages.mag.query_mag_sparql.requests.get', autospec=True)
+def test_get_eu_countries_returns_countries(mocked_requests):
+    some_html = '''
+        <div id="content" style="max-width:950px">
+        <div class="table" id="year-entry2">
+        <table><tbody><tr><th class="table_th_pos_1" colspan="2">Countries</th>
+        </tr><tr><td><a href="">Austria</a></td> <td><a href="">Italy</a></td>
+        </tr><tr><td><a href="">Belgium</a></td> <td><a href="">Latvia</a></td>
+        </tr></tbody></table></div>
+        </div>
+        '''
+    mocked_response = mock.Mock(text=some_html)
+    mocked_requests.return_value = mocked_response
+
+    assert get_eu_countries() == ['Austria', 'Italy', 'Belgium', 'Latvia']


### PR DESCRIPTION
MAG collection and estimation.

Currently a very inefficient query is used. Joining so many nodes results in a very slow query response from MAG.

This should be refactored to query a couple of nodes at a time and then join the results together, there will be some redundant data collected, as the filtering criteria can only be applied once all institutes and papers and known, but it results in far quicker queries.