### PR TITLE
Ngram fix

### DIFF
--- a/nesta/packages/nlp_utils/ngrammer.py
+++ b/nesta/packages/nlp_utils/ngrammer.py
@@ -94,7 +94,9 @@ class Ngrammer:
             processed_doc = []
             for sentence in text:
                 sentence = [token for token in sentence
-                            if token not in stop_words]
+                            if token not in stop_words and
+                            not all(len(t) <= 2 
+                                    for t in token.split('_'))]
                 processed_doc.append(sentence)
         return processed_doc
 

--- a/nesta/packages/nlp_utils/ngrammer.py
+++ b/nesta/packages/nlp_utils/ngrammer.py
@@ -95,7 +95,7 @@ class Ngrammer:
             for sentence in text:
                 sentence = [token for token in sentence
                             if token not in stop_words and
-                            not all(len(t) <= 2 
+                            not all(t in stop_words
                                     for t in token.split('_'))]
                 processed_doc.append(sentence)
         return processed_doc

--- a/nesta/packages/nlp_utils/preprocess.py
+++ b/nesta/packages/nlp_utils/preprocess.py
@@ -54,7 +54,7 @@ def clean_and_tokenize(text, remove_stops):
     tokens = tokens_re.findall(text)
     _tokens = [t.lower() for t in tokens]
     filtered_tokens = [token.replace('-', '_') for token in _tokens
-                       if len(token) > 2
+                       if (not remove_stops or len(token) > 2)
                        and (not remove_stops or token not in stop_words)
                        and not any(x in token for x in string.digits)
                        and any(x in token for x in string.ascii_lowercase)]

--- a/nesta/packages/nlp_utils/preprocess.py
+++ b/nesta/packages/nlp_utils/preprocess.py
@@ -54,7 +54,7 @@ def clean_and_tokenize(text, remove_stops):
     tokens = tokens_re.findall(text)
     _tokens = [t.lower() for t in tokens]
     filtered_tokens = [token.replace('-', '_') for token in _tokens
-                       if (not remove_stops or len(token) > 2)
+                       if not (remove_stops and len(token) <= 2)
                        and (not remove_stops or token not in stop_words)
                        and not any(x in token for x in string.digits)
                        and any(x in token for x in string.ascii_lowercase)]


### PR DESCRIPTION
ngrams were excluding any tokens containing terms with fewer than 2 chars, e.g. state-of-the-art