### PR TITLE
Fixed ngram bugs

### DIFF
--- a/nesta/core/batchables/arxiv/arxiv_elasticsearch/run.py
+++ b/nesta/core/batchables/arxiv/arxiv_elasticsearch/run.py
@@ -60,7 +60,7 @@ def run():
     
     # Setup ngrammer
     os.environ['MYSQLDBCONF'] = os.environ['BATCHPAR_config']
-    ngrammer = Ngrammer()
+    ngrammer = Ngrammer(database="production")
 
     # es setup
     strans_kwargs={'filename':'arxiv.json',

--- a/nesta/core/batchables/nlp/vectorizer/run.py
+++ b/nesta/core/batchables/nlp/vectorizer/run.py
@@ -23,7 +23,7 @@ def term_counts(dct, row, binary=False):
     """
     return {dct[idx]: (count if not binary else 1)
             for idx, count in Counter(dct.doc2idx(row)).items()
-            if idx != -1}        
+            if idx != -1 and dct[idx] != 'id'}        
 
 
 def optional(name, default):

--- a/nesta/core/routines/arxiv/arxiv_lolvelty.py
+++ b/nesta/core/routines/arxiv/arxiv_lolvelty.py
@@ -70,7 +70,7 @@ class ArxivLolveltyRootTask(luigi.WrapperTask):
                   'fields': ['textBody_abstract_article']}
         test = not self.production
         routine_id = f"ArxivLolveltyTask-{self.date}-{test}"
-        index = 'arxiv_v2' if self.production else 'arxiv_dev'
+        index = 'arxiv_v3' if self.production else 'arxiv_dev'
         return _ArxivElasticsearchTask(routine_id=routine_id,
                                        test=test,
                                        index=index,


### PR DESCRIPTION
Two bug fixes:

- did not specify `production` database, so only a limited subset of ngrams were being used (i.e. from `dev`)
- currently 'id' is a reserved term in vectorizer. It would be better if this were removed as a condition, but for now it stays in with the fix. Issue #198 opened.