### PR TITLE
Upgrade sentencepiece version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ s3fs==0.2.1
 scikit_learn==0.21.3
 scipy==1.2.2
 selenium==3.141.0
-sentencepiece==0.1.82
+sentencepiece==0.1.86
 setuptools==41.1.0
 six>=1.12.0
 SPARQLWrapper==1.8.4


### PR DESCRIPTION
Bumping `sentencepiece` version to `0.1.86`.

Closes #232 